### PR TITLE
Upgrade json-cpp to 1.9.5 (plus dfhack patches)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,17 +89,17 @@ option(JSONCPP_WITH_PKGCONFIG_SUPPORT "Generate and install .pc files" ON)
 option(JSONCPP_WITH_CMAKE_PACKAGE "Generate and install cmake package files" ON)
 option(JSONCPP_WITH_EXAMPLE "Compile JsonCpp example" OFF)
 option(JSONCPP_STATIC_WINDOWS_RUNTIME "Use static (MT/MTd) Windows runtime" OFF)
-option(BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." ON)
-option(BUILD_STATIC_LIBS "Build jsoncpp_lib as a static library." ON)
-option(BUILD_OBJECT_LIBS "Build jsoncpp_lib as a object library." ON)
+option(JSONCPP_BUILD_SHARED_LIBS "Build jsoncpp_lib as a shared library." ON)
+option(JSONCPP_BUILD_STATIC_LIBS "Build jsoncpp_lib as a static library." ON)
+option(JSONCPP_BUILD_OBJECT_LIBS "Build jsoncpp_lib as a object library." ON)
 
 # Adhere to GNU filesystem layout conventions
 include(GNUInstallDirs)
 
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Archive output dir.")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Library output dir.")
-set(CMAKE_PDB_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/bin" CACHE PATH "PDB (MSVC debug symbol)output dir.")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Executable/dll output dir.")
+#set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Archive output dir.")
+#set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib" CACHE PATH "Library output dir.")
+#set(CMAKE_PDB_OUTPUT_DIRECTORY     "${CMAKE_BINARY_DIR}/bin" CACHE PATH "PDB (MSVC debug symbol)output dir.")
+#set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin" CACHE PATH "Executable/dll output dir.")
 
 set(JSONCPP_USE_SECURE_MEMORY "0" CACHE STRING "-D...=1 to use memory-wiping allocator for STL")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,11 +111,11 @@ macro(use_compilation_warning_as_error)
     if(MSVC)
         # Only enabled in debug because some old versions of VS STL generate
         # warnings when compiled in release configuration.
-        add_compile_options($<$<CONFIG:Debug>:/WX>)
+        #add_compile_options($<$<CONFIG:Debug>:/WX>)
     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        add_compile_options(-Werror)
+        #add_compile_options(-Werror)
         if(JSONCPP_WITH_STRICT_ISO)
-            add_compile_options(-pedantic-errors)
+            #add_compile_options(-pedantic-errors)
         endif()
     endif()
 endmacro()
@@ -134,35 +134,35 @@ endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # using regular Clang or AppleClang
-    add_compile_options(-Wall -Wconversion -Wshadow)
+    #add_compile_options(-Wall -Wconversion -Wshadow)
 
     if(JSONCPP_WITH_WARNING_AS_ERROR)
-        add_compile_options(-Werror=conversion -Werror=sign-compare)
+        #add_compile_options(-Werror=conversion -Werror=sign-compare)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # using GCC
-    add_compile_options(-Wall -Wconversion -Wshadow -Wextra)
+    #add_compile_options(-Wall -Wconversion -Wshadow -Wextra)
     # not yet ready for -Wsign-conversion
 
     if(JSONCPP_WITH_STRICT_ISO)
-        add_compile_options(-Wpedantic)
+        #add_compile_options(-Wpedantic)
     endif()
     if(JSONCPP_WITH_WARNING_AS_ERROR)
-        add_compile_options(-Werror=conversion)
+        #add_compile_options(-Werror=conversion)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     # using Intel compiler
-    add_compile_options(-Wall -Wconversion -Wshadow -Wextra)
+    #add_compile_options(-Wall -Wconversion -Wshadow -Wextra)
 
     if(JSONCPP_WITH_WARNING_AS_ERROR)
-        add_compile_options(-Werror=conversion)
+        #add_compile_options(-Werror=conversion)
     elseif(JSONCPP_WITH_STRICT_ISO)
-        add_compile_options(-Wpedantic)
+        #add_compile_options(-Wpedantic)
     endif()
 endif()
 
 if(JSONCPP_WITH_WARNING_AS_ERROR)
-    use_compilation_warning_as_error()
+    #use_compilation_warning_as_error()
 endif()
 
 if(JSONCPP_WITH_PKGCONFIG_SUPPORT)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@ build_script:
   - set JSONCPP_BUILD_FOLDER=%JSONCPP_FOLDER%\build\release
   - mkdir -p %JSONCPP_BUILD_FOLDER%
   - cd %JSONCPP_BUILD_FOLDER%
-  - cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX:PATH=%CD:\=/%/install -DBUILD_SHARED_LIBS:BOOL=ON %JSONCPP_FOLDER%
+  - cmake -G "%CMAKE_GENERATOR%" -DCMAKE_INSTALL_PREFIX:PATH=%CD:\=/%/install -DJSONCPP_BUILD_SHARED_LIBS:BOOL=ON %JSONCPP_FOLDER%
   # Use ctest to make a dashboard build:
   # - ctest -D Experimental(Start|Update|Configure|Build|Test|Coverage|MemCheck|Submit)
   # NOTE: Testing on windows is not yet finished:

--- a/dev.makefile
+++ b/dev.makefile
@@ -18,7 +18,7 @@ dox:
 	# Then 'git add -A' and 'git push' in jsoncpp-docs.
 build:
 	mkdir -p build/debug
-	cd build/debug; cmake -DCMAKE_BUILD_TYPE=debug -DBUILD_SHARED_LIBS=ON -G "Unix Makefiles" ../..
+	cd build/debug; cmake -DCMAKE_BUILD_TYPE=debug -DJSONCPP_BUILD_SHARED_LIBS=ON -G "Unix Makefiles" ../..
 	make -C build/debug
 
 # Currently, this depends on include/json/version.h generated

--- a/devtools/agent_vmw7.json
+++ b/devtools/agent_vmw7.json
@@ -19,8 +19,8 @@
         },
         {"name": "shared_dll",
          "variables": [
-            ["BUILD_SHARED_LIBS=true"],
-            ["BUILD_SHARED_LIBS=false"]
+            ["JSONCPP_BUILD_SHARED_LIBS=true"],
+            ["JSONCPP_BUILD_SHARED_LIBS=false"]
           ]
         },
         {"name": "build_type",

--- a/devtools/agent_vmxp.json
+++ b/devtools/agent_vmxp.json
@@ -12,8 +12,8 @@
         },
         {"name": "shared_dll",
          "variables": [
-            ["BUILD_SHARED_LIBS=true"],
-            ["BUILD_SHARED_LIBS=false"]
+            ["JSONCPP_BUILD_SHARED_LIBS=true"],
+            ["JSONCPP_BUILD_SHARED_LIBS=false"]
           ]
         },
         {"name": "build_type",

--- a/src/jsontestrunner/CMakeLists.txt
+++ b/src/jsontestrunner/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(jsontestrunner_exe
     main.cpp
 )
 
-if(BUILD_SHARED_LIBS)
+if(JSONCPP_BUILD_SHARED_LIBS)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
         add_compile_definitions( JSON_DLL )
     else()

--- a/src/lib_json/CMakeLists.txt
+++ b/src/lib_json/CMakeLists.txt
@@ -108,7 +108,7 @@ list(APPEND REQUIRED_FEATURES
 )
 
 
-if(BUILD_SHARED_LIBS)
+if(JSONCPP_BUILD_SHARED_LIBS)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
         add_compile_definitions(JSON_DLL_BUILD)
     else()
@@ -121,7 +121,7 @@ if(BUILD_SHARED_LIBS)
         OUTPUT_NAME jsoncpp
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
+        POSITION_INDEPENDENT_CODE ${JSONCPP_BUILD_SHARED_LIBS}
     )
 
     # Set library's runtime search path on OSX
@@ -140,12 +140,12 @@ if(BUILD_SHARED_LIBS)
     list(APPEND CMAKE_TARGETS ${SHARED_LIB})
 endif()
 
-if(BUILD_STATIC_LIBS)
+if(JSONCPP_BUILD_STATIC_LIBS)
     set(STATIC_LIB ${PROJECT_NAME}_static)
     add_library(${STATIC_LIB} STATIC ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
 
     # avoid name clashes on windows as the shared import lib is alse named jsoncpp.lib
-    if(NOT DEFINED STATIC_SUFFIX AND BUILD_SHARED_LIBS)
+    if(NOT DEFINED STATIC_SUFFIX AND JSONCPP_BUILD_SHARED_LIBS)
         if (MSVC)
             set(STATIC_SUFFIX "_static")
         else()
@@ -174,7 +174,7 @@ if(BUILD_STATIC_LIBS)
     list(APPEND CMAKE_TARGETS ${STATIC_LIB})
 endif()
 
-if(BUILD_OBJECT_LIBS)
+if(JSONCPP_BUILD_OBJECT_LIBS)
     set(OBJECT_LIB ${PROJECT_NAME}_object)
     add_library(${OBJECT_LIB} OBJECT ${PUBLIC_HEADERS} ${JSONCPP_SOURCES})
 
@@ -182,7 +182,7 @@ if(BUILD_OBJECT_LIBS)
         OUTPUT_NAME jsoncpp
         VERSION ${PROJECT_VERSION}
         SOVERSION ${PROJECT_SOVERSION}
-        POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS}
+        POSITION_INDEPENDENT_CODE ${JSONCPP_BUILD_SHARED_LIBS}
     )
 
     # Set library's runtime search path on OSX

--- a/src/test_lib_json/CMakeLists.txt
+++ b/src/test_lib_json/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(jsoncpp_test
 )
 
 
-if(BUILD_SHARED_LIBS)
+if(JSONCPP_BUILD_SHARED_LIBS)
     if(CMAKE_VERSION VERSION_GREATER_EQUAL 3.12.0)
         add_compile_definitions( JSON_DLL )
     else()


### PR DESCRIPTION
DFHack/dfhack#2131

Incorporates patches from #1

dfhack changes:
- Update public API in CMake to match that in the meson build spec (so the correct header files are included)
- prefix options with JSONCPP_ (so they don't pollute the dfhack option namespace)
- undo jsoncpp attempt to generate *more* warnings (so we don't break our `-Werror` enabled build)